### PR TITLE
Bump version: 0.1.4 -> 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "threadpool"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Bumped to 0.2.0 instead of 0.1.5 because the `scoped-pool` feature was
removed, which could break code.