### PR TITLE
Add set_threads function to set thread number at runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "threadpool"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This PR builds on PR #15, adding not only the ```max_count``` and ```active_count``` functions but also the ```set_threads``` function to change the thread number at runtime, and is, at the time of writing, fully up to date with the current repo. Essentially, the ```set_threads``` function changes the maximum thread number, and if the new thread number is more than the current one, the ```set_threads``` function spawns threads to compensate. If the new thread number is less than the current one, existing threads will end after they finish their current job (they won't be killed). A lot of variable names are kind of iffy, so any input would be appreciated. 