### PR TITLE
Use atomic counters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,8 @@
 //! Abstraction of a thread pool for basic parallelism.
 
 use std::sync::mpsc::{channel, Sender, Receiver};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 
 trait FnBox {
@@ -28,15 +29,15 @@ type Thunk<'a> = Box<FnBox + Send + 'a>;
 
 struct Sentinel<'a> {
     jobs: &'a Arc<Mutex<Receiver<Thunk<'static>>>>,
-    thread_counter: &'a Arc<RwLock<usize>>,
-    thread_count_max: &'a Arc<Mutex<usize>>,
+    thread_counter: &'a Arc<AtomicUsize>,
+    thread_count_max: &'a Arc<AtomicUsize>,
     active: bool
 }
 
 impl<'a> Sentinel<'a> {
     fn new(jobs: &'a Arc<Mutex<Receiver<Thunk<'static>>>>,
-           thread_counter: &'a Arc<RwLock<usize>>,
-           thread_count_max: &'a Arc<Mutex<usize>>) -> Sentinel<'a> {
+           thread_counter: &'a Arc<AtomicUsize>,
+           thread_count_max: &'a Arc<AtomicUsize>) -> Sentinel<'a> {
         Sentinel {
             jobs: jobs,
             thread_counter: thread_counter,
@@ -54,7 +55,7 @@ impl<'a> Sentinel<'a> {
 impl<'a> Drop for Sentinel<'a> {
     fn drop(&mut self) {
         if self.active {
-            *self.thread_counter.write().unwrap() -= 1;
+            self.thread_counter.fetch_sub(1, Ordering::SeqCst);
             spawn_in_pool(self.jobs.clone(), self.thread_counter.clone(), self.thread_count_max.clone())
         }
     }
@@ -71,17 +72,19 @@ impl<'a> Drop for Sentinel<'a> {
 /// use threadpool::ThreadPool;
 /// use std::sync::mpsc::channel;
 ///
-/// let pool = ThreadPool::new(4);
+/// let n_workers = 4;
+/// let n_jobs = 8;
+/// let pool = ThreadPool::new(n_workers);
 ///
 /// let (tx, rx) = channel();
-/// for i in 0..8 {
+/// for i in 0..n_jobs {
 ///     let tx = tx.clone();
 ///     pool.execute(move|| {
 ///         tx.send(i).unwrap();
 ///     });
 /// }
 ///
-/// assert_eq!(rx.iter().take(8).fold(0, |a, b| a + b), 28);
+/// assert_eq!(rx.iter().take(n_jobs).fold(0, |a, b| a + b), 28);
 /// ```
 #[derive(Clone)]
 pub struct ThreadPool {
@@ -91,8 +94,8 @@ pub struct ThreadPool {
     // quit.
     jobs: Sender<Thunk<'static>>,
     job_receiver: Arc<Mutex<Receiver<Thunk<'static>>>>,
-    active_count: Arc<RwLock<usize>>,
-    max_count: Arc<Mutex<usize>>,
+    active_count: Arc<AtomicUsize>,
+    max_count: Arc<AtomicUsize>,
 }
 
 impl ThreadPool {
@@ -106,8 +109,8 @@ impl ThreadPool {
 
         let (tx, rx) = channel::<Thunk<'static>>();
         let rx = Arc::new(Mutex::new(rx));
-        let active_count = Arc::new(RwLock::new(0));
-        let max_count = Arc::new(Mutex::new(threads));
+        let active_count = Arc::new(AtomicUsize::new(0));
+        let max_count = Arc::new(AtomicUsize::new(threads));
 
         // Threadpool threads
         for _ in 0..threads {
@@ -131,20 +134,20 @@ impl ThreadPool {
 
     /// Returns the number of currently active threads.
     pub fn active_count(&self) -> usize {
-        *self.active_count.read().unwrap()
+        self.active_count.load(Ordering::Relaxed)
     }
 
     /// Returns the number of created threads
     pub fn max_count(&self) -> usize {
-        *self.max_count.lock().unwrap()
+        self.max_count.load(Ordering::Relaxed)
     }
 
     /// Sets the number of threads to use as `threads`.
-    /// Can be used to change the threadpool size during runtime
+    /// Can be used to change the threadpool size during runtime.
+    /// Will not abort already running or waiting threads.
     pub fn set_threads(&mut self, threads: usize) {
         assert!(threads >= 1);
-        let current_max = self.max_count.lock().unwrap().clone();
-        *self.max_count.lock().unwrap() = threads;
+        let current_max = (*self.max_count).swap(threads, Ordering::Release);
         if threads > current_max {
             // Spawn new threads
             for _ in 0..(threads - current_max) {
@@ -155,16 +158,16 @@ impl ThreadPool {
 }
 
 fn spawn_in_pool(jobs: Arc<Mutex<Receiver<Thunk<'static>>>>,
-                 thread_counter: Arc<RwLock<usize>>,
-                 thread_count_max: Arc<Mutex<usize>>) {
+                 thread_counter: Arc<AtomicUsize>,
+                 thread_count_max: Arc<AtomicUsize>) {
     thread::spawn(move || {
         // Will spawn a new thread on panic unless it is cancelled.
         let sentinel = Sentinel::new(&jobs, &thread_counter, &thread_count_max);
 
         loop {
-            // clone values so that the mutexes are not held
-            let thread_counter_val = thread_counter.read().unwrap().clone();
-            let thread_count_max_val = thread_count_max.lock().unwrap().clone();
+            // Shutdown this thread if the pool has become smaller
+            let thread_counter_val = thread_counter.load(Ordering::Acquire);
+            let thread_count_max_val = thread_count_max.load(Ordering::Relaxed);
             if thread_counter_val < thread_count_max_val {
                 let message = {
                     // Only lock jobs for the time it takes
@@ -175,12 +178,13 @@ fn spawn_in_pool(jobs: Arc<Mutex<Receiver<Thunk<'static>>>>,
 
                 match message {
                     Ok(job) => {
-                        *thread_counter.write().unwrap() += 1;
+                        // Do not allow IR around the job execution
+                        thread_counter.fetch_add(1, Ordering::SeqCst);
                         job.call_box();
-                        *thread_counter.write().unwrap() -= 1;
+                        thread_counter.fetch_sub(1, Ordering::SeqCst);
                     },
 
-                    // The Threadpool was dropped.
+                    // The ThreadPool was dropped.
                     Err(..) => break
                 }
             } else {
@@ -204,7 +208,7 @@ mod test {
 
     #[test]
     fn test_set_threads_increasing() {
-        let new_thread_amount = 6;
+        let new_thread_amount = TEST_TASKS + 8;
         let mut pool = ThreadPool::new(TEST_TASKS);
         for _ in 0..TEST_TASKS {
             pool.execute(move || {
@@ -221,7 +225,7 @@ mod test {
                 }
             });
         }
-        sleep_ms(1000);
+        sleep_ms(1024);
         assert_eq!(pool.active_count(), new_thread_amount);
     }
 
@@ -242,7 +246,7 @@ mod test {
                 }
             });
         }
-        sleep_ms(1000);
+        sleep_ms(1024);
         assert_eq!(pool.active_count(), new_thread_amount);
     }
 
@@ -256,7 +260,7 @@ mod test {
                 }
             });
         }
-        sleep_ms(1000);
+        sleep_ms(1024);
         let active_count = pool.active_count();
         assert_eq!(active_count, TEST_TASKS);
         let initialized_count = pool.max_count();
@@ -316,7 +320,7 @@ mod test {
             let waiter = waiter.clone();
             pool.execute(move|| {
                 waiter.wait();
-                panic!();
+                panic!("Ignore this panic, it should!");
             });
         }
 
@@ -324,5 +328,80 @@ mod test {
 
         // Kick off the failure.
         waiter.wait();
+    }
+
+    #[test]
+    fn test_massive_task_creation() {
+        let test_tasks = 4_200_000;
+        
+        let pool = ThreadPool::new(TEST_TASKS);
+        let b0 = Arc::new(Barrier::new(TEST_TASKS +1));
+        let b1 = Arc::new(Barrier::new(TEST_TASKS +1));
+
+        let (tx, rx) = channel();
+        
+        for i in 0..test_tasks {
+            let tx = tx.clone();
+            let (b0, b1) = (b0.clone(), b1.clone());
+            
+            pool.execute(move|| {
+                
+                // Wait until the pool has been filled once.
+                if i < TEST_TASKS {
+                    b0.wait();
+                    // wait so the pool can be measured
+                    b1.wait();
+                }
+                
+                tx.send(1).is_ok();
+            });
+        }
+        
+        b0.wait();
+        assert_eq!(pool.active_count(), TEST_TASKS);
+        b1.wait();
+
+        assert_eq!(rx.iter().take(test_tasks).fold(0, |a, b| a + b), test_tasks);
+        // `iter().take(test_tasks).fold` may be faster than the last thread finishing itself, so values of 0 or 1 are ok.
+        assert!(pool.active_count() <= 1);
+    }
+    
+    #[test]
+    fn test_shrink() {
+        let test_tasks_begin = TEST_TASKS + 2;
+        
+        let mut pool = ThreadPool::new(test_tasks_begin);
+        let b0 = Arc::new(Barrier::new(test_tasks_begin +1));
+        let b1 = Arc::new(Barrier::new(test_tasks_begin +1));
+        
+        for _ in 0..test_tasks_begin {
+            let (b0, b1) = (b0.clone(), b1.clone());
+            pool.execute(move|| {
+                b0.wait();
+                b1.wait();
+            });
+        }
+        
+        let b2 = Arc::new(Barrier::new(TEST_TASKS +1));
+        let b3 = Arc::new(Barrier::new(TEST_TASKS +1));
+        
+        for _ in 0..TEST_TASKS {
+            let (b2, b3) = (b2.clone(), b3.clone());
+            pool.execute(move|| {
+                b2.wait();
+                b3.wait();
+            });
+        }
+        
+        b0.wait();
+        pool.set_threads(TEST_TASKS);
+        
+        assert_eq!(pool.active_count(), test_tasks_begin);
+        b1.wait();
+        
+        
+        b2.wait();
+        assert_eq!(pool.active_count(), TEST_TASKS);
+        b3.wait();
     }
 }


### PR DESCRIPTION
I tried making the pool faster on NUMA systems but the effect is very minor, because the channel uses a Mutex.

However, since I already did the work, I would like to share it.

Should I rebase the history into one commit?