### PR TITLE
Enable `#[deprecated]` doc, requires rust 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+sudo: false
 language: rust
+cache: cargo
 rust:
-  - 1.4.0
+  - 1.9.0
   - beta
   - nightly
 before_script:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 1.3.2
+
+* [Enable `#[deprecated]` doc, requires rust 1.9](https://github.com/frewsxcv/rust-threadpool/pull/38)
+
 ## 1.3.1
 
 * [Implement std::fmt::Debug for ThreadPool](https://github.com/frewsxcv/rust-threadpool/pull/50)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-threadpool
-==========
+# threadpool
 
 A thread pool for running a number of jobs on a fixed set of worker threads.
 
@@ -21,6 +20,10 @@ and this to your crate root:
 ```rust
 extern crate threadpool;
 ```
+
+## Minimal requirements
+
+This crate requires rust >= 1.9.0
 
 ## Similar libraries
 

--- a/lib.rs
+++ b/lib.rs
@@ -289,8 +289,7 @@ impl ThreadPool {
     }
 
     /// **Deprecated: Use `ThreadPool::set_num_threads`**
-    // #[deprecated(since = "1.3.0", note = "use ThreadPool::set_num_threads")]
-    // TODO: #[deprecated] isn't stable yet.
+    #[deprecated(since = "1.3.0", note = "use ThreadPool::set_num_threads")]
     pub fn set_threads(&mut self, num_threads: usize) {
         self.set_num_threads(num_threads)
     }

--- a/lib.rs
+++ b/lib.rs
@@ -547,7 +547,8 @@ mod test {
         assert_eq!(rx.iter().take(test_tasks).fold(0, |a, b| a + b), test_tasks);
         // `iter().take(test_tasks).fold` may be faster than the last thread finishing itself, so
         // values of 0 or 1 are ok.
-        assert!(pool.active_count() <= 1);
+        let atomic_active_count = pool.active_count();
+        assert!(atomic_active_count <= 1, "atomic_active_count: {}", atomic_active_count);
     }
 
     #[test]


### PR DESCRIPTION
Rust 1.9 is stable now