### PR TITLE
Simplify math in example.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,14 +28,14 @@
 //! let pool = ThreadPool::new(n_workers);
 //!
 //! let (tx, rx) = channel();
-//! for i in 0..n_jobs {
+//! for _ in 0..n_jobs {
 //!     let tx = tx.clone();
 //!     pool.execute(move|| {
-//!         tx.send(i).unwrap();
+//!         tx.send(1).unwrap();
 //!     });
 //! }
 //!
-//! assert_eq!(rx.iter().take(n_jobs).fold(0, |a, b| a + b), 28);
+//! assert_eq!(rx.iter().take(n_jobs).fold(0, |a, b| a + b), 8);
 //! ```
 //!
 //! ## Syncronized with a barrier


### PR DESCRIPTION
Accidentally lost ed0e2fd4da5f04eca7b16aa3aa0d945d028cfe00 when I did
e4a58319907b42573bf12e218bcabb15abf65f92.