### PR TITLE
Take thread name with a conversion trait

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -182,7 +182,7 @@ impl ThreadPool {
     /// use threadpool::ThreadPool;
     ///
     /// let (tx, rx) = sync_channel(0);
-    /// let mut pool = ThreadPool::new_with_name("worker".into(), 2);
+    /// let mut pool = ThreadPool::new_with_name("worker", 2);
     /// for _ in 0..2 {
     ///     let tx = tx.clone();
     ///     pool.execute(move || {
@@ -197,8 +197,10 @@ impl ThreadPool {
     /// ```
     ///
     /// [thread name]: https://doc.rust-lang.org/std/thread/struct.Thread.html#method.name
-    pub fn new_with_name(name: String, num_threads: usize) -> ThreadPool {
-        ThreadPool::new_pool(Some(name), num_threads)
+    pub fn new_with_name<S>(name: S, num_threads: usize) -> ThreadPool
+        where S: Into<String>
+    {
+        ThreadPool::new_pool(Some(name.into()), num_threads)
     }
 
     #[inline]


### PR DESCRIPTION
This allows a caller to pass either a `String` or `&str` as the name for the ThreadPool. Obviously a very minor change but I suspect many folks are using `&'static str`s as their thread pool name.
