### PR TITLE
Remove redundant closure

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -236,7 +236,7 @@ impl ThreadPool {
     pub fn execute<F>(&self, job: F)
         where F: FnOnce() + Send + 'static
     {
-        self.jobs.send(Box::new(move || job())).unwrap();
+        self.jobs.send(Box::new(job)).unwrap();
     }
 
     /// Returns the number of currently active threads.


### PR DESCRIPTION
Type T which implement FnOnce() should be directly moved into a box.