### PR TITLE
Add test to make sure the types in the pool stay Send and/or Sync

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -904,4 +904,22 @@ mod test {
 
         pool.join();
     }
+
+    #[test]
+    fn test_sync_shared_data() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<super::ThreadPoolSharedData>();
+    }
+
+    #[test]
+    fn test_send_shared_data() {
+        fn assert_send<T: Send>() {}
+        assert_send::<super::ThreadPoolSharedData>();
+    }
+
+    #[test]
+    fn test_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ThreadPool>();
+    }
 }


### PR DESCRIPTION
The tests are run at compile time. Found the trick at [the api-guidlines](https://rust-lang-nursery.github.io/api-guidelines/interoperability.html#types-are-send-and-sync-where-possible-c-send-sync).